### PR TITLE
refactor: pass @actions/exec args as array

### DIFF
--- a/main.js
+++ b/main.js
@@ -94,7 +94,7 @@ async function configureAuthentication() {
 
   // Use platform-specific command
   const command = process.platform === 'win32' ? 'upctl.exe' : 'upctl';
-  await exec.exec(`${command} account show`, [], { silent: true });
+  await exec.exec(command, ['account', 'show'], { silent: true });
   core.info('✓ UpCloud CLI authentication verified successfully');
 }
 


### PR DESCRIPTION
They're all constants without problematic characters in this use case so there's no substantial difference, but for general hygiene.

Caveat: untested.